### PR TITLE
Bug in Atlassian products

### DIFF
--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -46,7 +46,7 @@ query = [
 
   tmp = (-1 === tmp.indexOf(":") ? "http://" : "") + tmp;                                 /* fix missing protocol */
 function for_twitter(element) {
-  tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url"); // twitter/instagram pages
+  var tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url"); // twitter/instagram pages
   if (tmp) {
     element.setAttribute("href", tmp); // hard overwrite
     element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
@@ -54,13 +54,12 @@ function for_twitter(element) {
 }
 
 function for_google_nojs(element) {
-  tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i); // Google page (redirects with no JS)
+  var tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i); // Google page (redirects with no JS)
   if(tmp && typeof tmp[1] === "string") {
     tmp = tmp[1];
     tmp = decodeURIComponent(tmp);
     element.setAttribute("href", tmp); // hard overwrite
     element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
-
   }
 }
 
@@ -70,9 +69,6 @@ function action(){
     counter_total += elements.length;
     try { chrome.runtime.sendMessage( {badge_data: counter_total} ); } catch(err){} // update extension's badge
 
-
-    setTimeout(function(){    /*setTimeout run only if there is a JS support on the page. cloneNode trick will break the "for_twitter" and "for_google_nojs", there-for it is only in the setTimeout block which will be executed on a JS-supported page, since with JS-support it will not break the "for_twitter" and "for_google_nojs". */
-      tmp = element.cloneNode(true);
     elements.forEach(function(element){
       element.removeAttribute("onmousedown");
       element.removeAttribute("jsaction");
@@ -80,6 +76,8 @@ function action(){
       for_twitter(element);
       for_google_nojs(element);
 
+      setTimeout(function(){ // will only run if there is a JS-support on the page
+        var tmp = element.cloneNode(true); // will break the "for_twitter" and "for_google_nojs"; therefore, it is only in the setTimeout block which will be executed on a JS-supported page, since with JS-support it will not break the "for_twitter" and "for_google_nojs"
         element.parentNode.replaceChild(tmp, element);
         element.removeAttribute("onmousedown"); // must be redo
         element.removeAttribute("jsaction");

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -44,10 +44,10 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])'   
 ].join(', ');
 
-  tmp = (-1 === tmp.indexOf(":") ? "http://" : "") + tmp;                                 /* fix missing protocol */
 function for_twitter(element) {
   var tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url"); // twitter/instagram pages
   if (tmp) {
+    tmp = new URL(tmp, location); // fix missing protocol
     element.setAttribute("href", tmp); // hard overwrite
     element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
   }

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -44,27 +44,29 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])'   
 ].join(', ');
 
-  if(tmp === null) return;
   tmp = (-1 === tmp.indexOf(":") ? "http://" : "") + tmp;                                 /* fix missing protocol */
 function for_twitter(element) {
   tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url"); // twitter/instagram pages
+  if (tmp) {
     element.setAttribute("href", tmp); // hard overwrite
     element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
+  }
 }
 
 function for_google_nojs(element) {
   tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i); // Google page (redirects with no JS)
+  if(tmp && typeof tmp[1] === "string") {
     tmp = tmp[1];
     tmp = decodeURIComponent(tmp);
     element.setAttribute("href", tmp); // hard overwrite
     element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
 
-  if(tmp === null || typeof tmp[1] !== "string") return;
+  }
 }
 
 function action(){
   var elements = document.querySelectorAll(query);
-  if(elements === null || elements.length === 0) return;
+  if (elements && elements.length > 0) {
     counter_total += elements.length;
     try { chrome.runtime.sendMessage( {badge_data: counter_total} ); } catch(err){} // update extension's badge
 
@@ -87,6 +89,7 @@ function action(){
       }, 50);
     });
   }
+}
 
 try { action(); } catch(err){}
 try { interval_id = setInterval(action, 500); } catch(err) { clearInterval(interval_id); } // only available in pages having JS-support

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -38,10 +38,10 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.replace("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.reload("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.assign("]'
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-url]:not([data-url=""]):not([done-remove-redirects])'                      /* twitter/instagram links ("t.co"/) links   */
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="openUrl("]' // quora.com
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])'   
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("]):not([onclick]):not([onmousedown]):not([jsaction])[href^="/url?q="]:not([done-remove-redirects])' // Google with no JS URL - must be verified to be Google, using '.href'; this is special case, and a little bit wasteful, since I KNOW there is NO onclick,onmousedown(etc..) handles due to it is being in no JS page, but to make the entire code at here more unified- I WILL STILL include this specific case as if it is still required to be handled-cleaned
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-url]:not([data-url=""]):not(.aui-button):not([done-remove-redirects])' // ignore Atlassian products (.aui-button)
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])' // twitter/instagram links ("t.co"/) links
 ].join(', ');
 
 function for_twitter(element) {

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -47,7 +47,7 @@ query = [
 
 function for_twitter(element){
   tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url");      /* twitter instagram pages*/
-  if(null === tmp) return;
+  if(tmp === null) return;
   tmp = (-1 === tmp.indexOf(":") ? "http://" : "") + tmp;                                 /* fix missing protocol */
   element.setAttribute("href", tmp);                                                      /* hard overwrite       */
   element.setAttribute("done-remove-redirects", "");                                                       /* flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it.  */
@@ -56,7 +56,7 @@ function for_twitter(element){
 
 function for_google_nojs(element){
   tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i);                   /* Google page (redirects with no javascript)*/
-  if(null === tmp || "string" !== typeof tmp[1]) return;
+  if(tmp === null || typeof tmp[1] !== "string") return;
   tmp = tmp[1];
   tmp = decodeURIComponent(tmp);
   element.setAttribute("href", tmp); /* hard overwrite */
@@ -66,7 +66,7 @@ function for_google_nojs(element){
 
 function action(){
   var elements = document.querySelectorAll(query);
-  if(null === elements || 0 === elements.length) return;
+  if(elements === null || elements.length === 0) return;
   counter_total += elements.length;
   try{chrome.runtime.sendMessage({badge_data: counter_total});}catch(err){} /* update extension's badge. */
 

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -40,8 +40,8 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.assign("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-url]:not([data-url=""]):not([done-remove-redirects])'                      /* twitter/instagram links ("t.co"/) links   */
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="openUrl("]' // quora.com
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("]):not([onclick]):not([onmousedown]):not([jsaction])[href^="/url?q="]:not([done-remove-redirects])' //  Google with no JS URL - must be verified to be Google, using '.href'; this is special case, and a little bit wasteful, since I KNOW there is NO onclick,onmousedown(etc..) handles due to it is being in no JS page, but to make the entire code at here more unified- I WILL STILL include this specific case as if it is still required to be handled-cleaned
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])'   
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("]):not([onclick]):not([onmousedown]):not([jsaction])[href^="/url?q="]:not([done-remove-redirects])' // Google with no JS URL - must be verified to be Google, using '.href'; this is special case, and a little bit wasteful, since I KNOW there is NO onclick,onmousedown(etc..) handles due to it is being in no JS page, but to make the entire code at here more unified- I WILL STILL include this specific case as if it is still required to be handled-cleaned
 ].join(', ');
 
 function for_twitter(element) {

--- a/resources/at_document_start.js
+++ b/resources/at_document_start.js
@@ -12,9 +12,9 @@ NodeList.prototype.forEach = Array.prototype.forEach;
 counter_total = 0;
 
 query = [
-  '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="rwt("]'                        /* Google              */
+  '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="rwt("]' // Google
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[jsaction*="mousedown"][jsaction*="keydown"]'
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="window.open("]'                /* other (very common) */
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="window.open("]' // other (very common)
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="self.open("]' 
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="top.open("]' 
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="parent.open("]' 
@@ -26,7 +26,7 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="location.replace("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="location.reload("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onmousedown*="location.assign("]'
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="window.open("]'                         /* other (uncommon)                      */
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="window.open("]' // other (uncommon)
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="self.open("]' 
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="top.open("]' 
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="parent.open("]' 
@@ -38,57 +38,55 @@ query = [
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.replace("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.reload("]'
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="location.assign("]'
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="openUrl("]'                                          /* quora.com                             */
-, '[href]:not([href=""]):not([href^="#"]):not([href*="void("]):not([onclick]):not([onmousedown]):not([jsaction])[href^="/url?q="]:not([done-remove-redirects])'     /* Google with no JavaScript URL - must be verified to be Google, using '.href'  --  this is special case, and a little bit wastefull, since I KNOW there is NO onclick,onmousedown(etc..) handles due to it is being in no javascript page, but to make the entire code at here more unified- I WILL STILL include this specific case as if it is still required to be handled-cleaned.. */
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-url]:not([data-url=""]):not([done-remove-redirects])'                      /* twitter/instagram links ("t.co"/) links   */
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[onclick*="openUrl("]' // quora.com
+, '[href]:not([href=""]):not([href^="#"]):not([href*="void("]):not([onclick]):not([onmousedown]):not([jsaction])[href^="/url?q="]:not([done-remove-redirects])' //  Google with no JS URL - must be verified to be Google, using '.href'; this is special case, and a little bit wasteful, since I KNOW there is NO onclick,onmousedown(etc..) handles due to it is being in no JS page, but to make the entire code at here more unified- I WILL STILL include this specific case as if it is still required to be handled-cleaned
 , '[href]:not([href=""]):not([href^="#"]):not([href*="void("])[data-expanded-url]:not([data-expanded-url=""]):not([done-remove-redirects])'   
 ].join(', ');
 
-
-function for_twitter(element){
-  tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url");      /* twitter instagram pages*/
   if(tmp === null) return;
   tmp = (-1 === tmp.indexOf(":") ? "http://" : "") + tmp;                                 /* fix missing protocol */
-  element.setAttribute("href", tmp);                                                      /* hard overwrite       */
-  element.setAttribute("done-remove-redirects", "");                                                       /* flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it.  */
+function for_twitter(element) {
+  tmp = element.getAttribute("data-url") || element.getAttribute("data-expanded-url"); // twitter/instagram pages
+    element.setAttribute("href", tmp); // hard overwrite
+    element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
 }
 
+function for_google_nojs(element) {
+  tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i); // Google page (redirects with no JS)
+    tmp = tmp[1];
+    tmp = decodeURIComponent(tmp);
+    element.setAttribute("href", tmp); // hard overwrite
+    element.setAttribute("done-remove-redirects", ""); // flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it
 
-function for_google_nojs(element){
-  tmp = element.href.match(/\/\/www\.google\.[^\/]+\/url\?q\=([^\&]+)/i);                   /* Google page (redirects with no javascript)*/
   if(tmp === null || typeof tmp[1] !== "string") return;
-  tmp = tmp[1];
-  tmp = decodeURIComponent(tmp);
-  element.setAttribute("href", tmp); /* hard overwrite */
-  element.setAttribute("done-remove-redirects", "");  /* flag to make sure to avoid infinate loop in-case the real-url also includes "/url?q=" in it.  */
 }
-
 
 function action(){
   var elements = document.querySelectorAll(query);
   if(elements === null || elements.length === 0) return;
-  counter_total += elements.length;
-  try{chrome.runtime.sendMessage({badge_data: counter_total});}catch(err){} /* update extension's badge. */
+    counter_total += elements.length;
+    try { chrome.runtime.sendMessage( {badge_data: counter_total} ); } catch(err){} // update extension's badge
 
-  elements.forEach(function(element){
-    element.removeAttribute("onmousedown");
-    element.removeAttribute("jsaction");
-    element.removeAttribute("onclick");
-    for_twitter(element);
-    for_google_nojs(element);
 
     setTimeout(function(){    /*setTimeout run only if there is a JS support on the page. cloneNode trick will break the "for_twitter" and "for_google_nojs", there-for it is only in the setTimeout block which will be executed on a JS-supported page, since with JS-support it will not break the "for_twitter" and "for_google_nojs". */
       tmp = element.cloneNode(true);
-      element.parentNode.replaceChild(tmp, element);
-      element.removeAttribute("onmousedown");                                                 /* must be redo */
+    elements.forEach(function(element){
+      element.removeAttribute("onmousedown");
       element.removeAttribute("jsaction");
       element.removeAttribute("onclick");
       for_twitter(element);
       for_google_nojs(element);
-    }, 50);
-  });
-}
 
+        element.parentNode.replaceChild(tmp, element);
+        element.removeAttribute("onmousedown"); // must be redo
+        element.removeAttribute("jsaction");
+        element.removeAttribute("onclick");
+        for_twitter(element);
+        for_google_nojs(element);
+      }, 50);
+    });
+  }
 
-try{  action();                               }catch(err){}
-try{  interval_id = setInterval(action, 500); }catch(err){ clearInterval(interval_id); }      /*only available in pages having JavaScript support*/
+try { action(); } catch(err){}
+try { interval_id = setInterval(action, 500); } catch(err) { clearInterval(interval_id); } // only available in pages having JS-support


### PR DESCRIPTION
I ran into a bug with Atlassian products (specifically JIRA, in this case) where a normal _href_ value was being replaced because Atlassian used _data-url_ to specify a link to documentation.

This is the HTML causing the issue:
```
<a id="invite_user" class="aui-button" href="/secure/admin/user/InviteUser!default.jspa" data-url="https://docs.atlassian.com/jira/jadm-docs-073/Create%2C+edit%2C+or+remove+a+user" title="Invite users to sign up by email" tabindex="0"> Invite users</a>
                        
<a id="create_user" class="aui-button" href="/secure/admin/user/AddUser!default.jspa" data-url="https://docs.atlassian.com/jira/jadm-docs-073/Create%2C+edit%2C+or+remove+a+user" title="Create a new user in the system" tabindex="0"> Create user</a>
```

This caused the button to point to the documentation instead of its intended function.

I made several commits to separate the other changes I made (mostly formatting). [This commit](https://github.com/jhult/Chrome-Extension-Remove-Redirects/commit/9d80331c6b4079e384ee55f30c374d40f75bbf95) contains the actual fix for Atlassian products.